### PR TITLE
download spacy model to support all models

### DIFF
--- a/app/entity_extractor.py
+++ b/app/entity_extractor.py
@@ -89,6 +89,7 @@ def get_extractor() -> SpacyExtractor:
         f"Loading spacy model {settings.nlp_spacy_model}. If the model is not already"
         " downloaded, this may take a while."
     )
+    spacy.cli.download(settings.nlp_spacy_model)
     nlp = spacy.load(settings.nlp_spacy_model)
     log.info(f"Loaded spacy model {settings.nlp_spacy_model}.")
 


### PR DESCRIPTION
NLP service does not work on some spacy models, for example: 'xx_ent_wiki_sm'. This PR downloads the model before loading and fixes this error.